### PR TITLE
Auto-assign 'jules' label on :octopus: emoji reaction

### DIFF
--- a/github.go
+++ b/github.go
@@ -271,6 +271,40 @@ func assignIssueToCopilot(ctx context.Context, rdb *redis.Client, issueURL, repo
 	return nil
 }
 
+func assignIssueToJules(ctx context.Context, rdb *redis.Client, issueURL, repo string, config Config) error {
+	// Parse the repository to get full org/repo format
+	repoFullName := parseRepoFullName(repo, config.GitHubOrg)
+
+	// Build the gh command to add jules label to issue
+	ghCmd := fmt.Sprintf("gh issue edit --add-label %q %s", issueJulesLabel, issueURL)
+
+	// Create Poppit command message
+	poppitCmd := PoppitCommand{
+		Repo:     repoFullName,
+		Branch:   "refs/heads/main",
+		Type:     "slash-vibe-issue-assign-jules",
+		Dir:      config.WorkingDir,
+		Commands: []string{ghCmd},
+		Metadata: map[string]interface{}{
+			"issueURL": issueURL,
+		},
+	}
+
+	payload, err := json.Marshal(poppitCmd)
+	if err != nil {
+		return fmt.Errorf("failed to marshal Poppit command: %v", err)
+	}
+
+	// Push command to Poppit list
+	err = rdb.RPush(ctx, config.RedisPoppitList, payload).Err()
+	if err != nil {
+		return fmt.Errorf("failed to push command to Poppit: %v", err)
+	}
+
+	Debug("Jules assignment command sent to Poppit for issue: %s", issueURL)
+	return nil
+}
+
 func sanitiseIssue(ctx context.Context, rdb *redis.Client, issueURL, repo string, deferCopilotAssignment bool, config Config) error {
 	// Parse the repository to get full org/repo format
 	repoFullName := parseRepoFullName(repo, config.GitHubOrg)

--- a/github_webhooks.go
+++ b/github_webhooks.go
@@ -46,6 +46,12 @@ func handleGitHubIssueEvent(ctx context.Context, rdb *redis.Client, slackClient 
 		handleIssueAssigned(ctx, rdb, slackClient, event, config)
 		return
 	}
+
+	// Handle issue labeled events
+	if event.Action == "labeled" {
+		handleIssueLabeled(ctx, rdb, slackClient, event, config)
+		return
+	}
 }
 
 func handleIssueClosed(ctx context.Context, rdb *redis.Client, slackClient *slack.Client, event GitHubWebhookEvent, config Config) {
@@ -141,4 +147,54 @@ func handleIssueAssigned(ctx context.Context, rdb *redis.Client, slackClient *sl
 	}
 
 	Debug("Sent sparkles reaction for message ts=%s", messageTs)
+}
+
+func handleIssueLabeled(ctx context.Context, rdb *redis.Client, slackClient *slack.Client, event GitHubWebhookEvent, config Config) {
+	Info("Received issue labeled event for issue #%d: %s", event.Issue.Number, event.Issue.Title)
+
+	// Check if label data is present
+	if event.Label == nil {
+		Warn("No label data in event")
+		return
+	}
+
+	// Check if label is "jules"
+	if event.Label.Name != issueJulesLabel {
+		Debug("Label is not jules: %s", event.Label.Name)
+		return
+	}
+
+	Debug("Issue labeled with jules")
+
+	// Use the html_url from the event payload
+	issueURL := event.Issue.HTMLURL
+	if issueURL == "" {
+		Warn("Missing html_url in issue event")
+		return
+	}
+
+	Debug("Issue URL: %s", issueURL)
+
+	// Search for the message with matching metadata
+	channelID, messageTs, err := findMessageByIssueURL(ctx, slackClient, issueURL, config)
+	if err != nil {
+		Error("Error finding message by issue URL: %v", err)
+		return
+	}
+
+	if channelID == "" || messageTs == "" {
+		Debug("No message found for issue URL: %s", issueURL)
+		return
+	}
+
+	Debug("Found message for issue %s at channel=%s, ts=%s", issueURL, channelID, messageTs)
+
+	// Send octopus reaction to SlackLiner
+	err = sendReactionToSlackLiner(ctx, rdb, julesReactionEmoji, channelID, messageTs, config)
+	if err != nil {
+		Error("Error sending reaction: %v", err)
+		return
+	}
+
+	Debug("Sent octopus reaction for message ts=%s", messageTs)
 }

--- a/handlers.go
+++ b/handlers.go
@@ -14,6 +14,8 @@ const (
 	issueAssignedReactionEmoji   = "sparkles"
 	issueSanitisedReactionEmoji  = "ticket"
 	issueSanitisingReactionEmoji = "brain"
+	issueJulesLabel              = "jules"
+	julesReactionEmoji           = "octopus"
 	issueClosedTTLSeconds        = 86400 // 24 hours
 	issueCreatedEventType        = "issue_created"
 	copilotAssigneeName          = "Copilot"

--- a/reactions.go
+++ b/reactions.go
@@ -48,8 +48,8 @@ func handleReactionAdded(ctx context.Context, rdb *redis.Client, slackClient *sl
 		}
 	}
 
-	// Only handle sparkles or ticket emoji
-	if reaction.Event.Reaction != "sparkles" && reaction.Event.Reaction != "ticket" {
+	// Only handle sparkles, ticket or octopus emoji
+	if reaction.Event.Reaction != "sparkles" && reaction.Event.Reaction != "ticket" && reaction.Event.Reaction != julesReactionEmoji {
 		return
 	}
 
@@ -121,6 +121,17 @@ func handleReactionAdded(ctx context.Context, rdb *redis.Client, slackClient *sl
 
 	// Handle different reactions
 	switch reaction.Event.Reaction {
+	case julesReactionEmoji:
+		Info("Assigning issue to Jules: %s", issueURL)
+
+		// Add jules label to issue
+		err = assignIssueToJules(ctx, rdb, issueURL, repository, config)
+		if err != nil {
+			Error("Error assigning issue to Jules: %v", err)
+			return
+		}
+
+		Info("Successfully sent Jules assignment command for: %s", issueURL)
 	case "sparkles":
 		if assignedToCopilot {
 			Debug("Issue already assigned to Copilot, ignoring reaction: %s", issueURL)

--- a/types.go
+++ b/types.go
@@ -86,6 +86,9 @@ type GitHubWebhookEvent struct {
 		Login string `json:"login"`
 		Type  string `json:"type"`
 	} `json:"assignee"`
+	Label *struct {
+		Name string `json:"name"`
+	} `json:"label"`
 	Issue struct {
 		URL           string `json:"url"`
 		HTMLURL       string `json:"html_url"`


### PR DESCRIPTION
This change implements automatic bi-directional synchronization between the 'jules' label on GitHub and the :octopus: emoji reaction on Slack. 

1. **Slack to GitHub**: When a user adds an :octopus: reaction to an issue confirmation message in Slack, the service now triggers a GitHub CLI command (via Poppit) to add the 'jules' label to the corresponding issue.
2. **GitHub to Slack**: When an issue is labeled with 'jules' on GitHub, the service receives a webhook event and automatically adds the :octopus: reaction to the corresponding Slack message in the confirmation channel.

Changes include:
- Updating `types.go` to support label data in GitHub webhooks.
- Adding necessary constants in `handlers.go`.
- Implementing `assignIssueToJules` in `github.go`.
- Updating reaction handling in `reactions.go`.
- Implementing webhook handling for labels in `github_webhooks.go`.

Fixes #89

---
*PR created automatically by Jules for task [4922628268211139309](https://jules.google.com/task/4922628268211139309) started by @vibe-chung*